### PR TITLE
Standard Field Translation: Image

### DIFF
--- a/assets/acf_5/qtranslatex.js
+++ b/assets/acf_5/qtranslatex.js
@@ -1,6 +1,15 @@
 
 (function(){
 
+	// Check for qtranslate-x
+	if ( 'object' !== typeof( qTranslateConfig ) || 'object' !== typeof( qTranslateConfig.qtx ) ) {
+		return;
+	}
+	// Check for ACF
+	if ( 'object' !== typeof( acf ) ) {
+		return;
+	}
+
 	acf.qtx = acf.qtx || {};
 
 	acf.qtx.image = function( field ) {
@@ -81,11 +90,6 @@
 		}
 
 		windowLoadCompleted = true;
-
-		// Only proceed if qTranslate is loaded
-		if (typeof qTranslateConfig != 'object' || typeof qTranslateConfig.qtx != 'object') {
-			return;
-		}
 
 		// Enable the language switching buttons
 		qTranslateConfig.qtx.enableLanguageSwitchingButtons('block');


### PR DESCRIPTION
Hello!

I was having issues using the `qtranslate_image` type with the latest qtranslate-x, so I extended the standard field translation to include the `image` type. A few notes:
- I put everything in an `acf.qtx.image` object. It seemed cleanest to me at the time, but I'm definitely not a full-time JS dev. If it makes sense to move this stuff into its own file, let me know.
- This currently checks the value of the existing displayed image and the language that the user switched to and skips the transition if they match. Otherwise, this will use an AJAX call to grab the image from the database on each language switch. Not ideal, but it currently works. Could probably fix this by keeping an internal language index in the `acf.qtx.image` object or something like that.

Hope you like it!
