### PR TITLE
WYSIWYG textarea appending all values

### DIFF
--- a/acf-qtranslate.php
+++ b/acf-qtranslate.php
@@ -3,7 +3,7 @@
 Plugin Name: Advanced Custom Fields: qTranslate
 Plugin URI: http://github.com/funkjedi/acf-qtranslate
 Description: Provides multilingual versions of the text, text area, and wysiwyg fields.
-Version: 1.7.8
+Version: 1.7.9
 Author: funkjedi
 Author URI: http://funkjedi.com
 License: GPLv2 or later

--- a/acf-qtranslate.php
+++ b/acf-qtranslate.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Plugin Name: Advanced Custom Fields: qTranslate
+Plugin Name: Advanced Custom Fields: qTranslate (Casumo Fork)
 Plugin URI: http://github.com/funkjedi/acf-qtranslate
 Description: Provides multilingual versions of the text, text area, and wysiwyg fields.
 Version: 1.7.9

--- a/src/acf_4/fields/wysiwyg.php
+++ b/src/acf_4/fields/wysiwyg.php
@@ -97,11 +97,11 @@ class acf_qtranslate_acf_4_wysiwyg extends acf_field_wysiwyg {
 
 					if( user_can_richedit() )
 					{
-						echo wp_richedit_pre( $field['value'] );
+						echo wp_richedit_pre( $value );
 					}
 					else
 					{
-						echo wp_htmledit_pre( $field['value'] );
+						echo wp_htmledit_pre( $value );
 					}
 
 					?></textarea>


### PR DESCRIPTION
The is a bug in acf4 wysiwyg field where using wysiwyg component for qtranslate will result in duplicate data everything a post is updated (pressing update button). Seems to be a typo correction as $value was never used in the create_field function.