### PR TITLE
Fixed undefined index (readonly, disabled) warning in text and text are…

### DIFF
--- a/src/acf_5/fields/text.php
+++ b/src/acf_5/fields/text.php
@@ -94,7 +94,7 @@ class acf_qtranslate_acf_5_text extends acf_field_text {
 
 		// special atts
 		foreach( $s as $k ) {
-			if( $field[ $k ] ) {
+			if( array_key_exists( $k, $field ) && $field[ $k ] ) {
 				$atts[ $k ] = $k;
 			}
 		}

--- a/src/acf_5/fields/textarea.php
+++ b/src/acf_5/fields/textarea.php
@@ -99,7 +99,7 @@ class acf_qtranslate_acf_5_textarea extends acf_field_textarea {
 
 		// special atts
 		foreach( $s as $k ) {
-			if( $field[ $k ] ) {
+			if( array_key_exists( $k, $field ) && $field[ $k ] ) {
 				$atts[ $k ] = $k;
 			}
 		}


### PR DESCRIPTION
…a fields.
When using text and text area fields inside a repeater (ACF 5.6.3), a warning saying 'readonly' and 'disable', both were 'undefined index' for some array. Checking for key existence before accessing the array solved it.

![image](https://user-images.githubusercontent.com/7982164/31557359-0a154396-b00e-11e7-9a2c-bbbe0a2091b5.png)
