### PR TITLE
Added "required" functionality for text field

### DIFF
--- a/src/acf_5/fields/text.php
+++ b/src/acf_5/fields/text.php
@@ -78,7 +78,7 @@ class acf_qtranslate_acf_5_text extends acf_field_text {
 
 		// vars
 		$o = array( 'type', 'id', 'class', 'name', 'value', 'placeholder' );
-		$s = array( 'readonly', 'disabled' );
+		$s = array( 'readonly', 'disabled', 'required' );
 		$e = '';
 
 		// maxlength


### PR DESCRIPTION
Added "required" to the $s array in the render_field() function, so that all languages fields are required.