### PR TITLE
Added "required" functionality for textarea field

### DIFF
--- a/src/acf_5/fields/textarea.php
+++ b/src/acf_5/fields/textarea.php
@@ -78,7 +78,7 @@ class acf_qtranslate_acf_5_textarea extends acf_field_textarea {
 
 		// vars
 		$o = array( 'id', 'class', 'name', 'placeholder', 'rows' );
-		$s = array( 'readonly', 'disabled' );
+		$s = array( 'readonly', 'disabled', 'required' );
 		$e = '';
 
 		// maxlength


### PR DESCRIPTION
Added "required" to the $s array in the render_field() function, so that all languages fields are required.